### PR TITLE
Add dark-theme and settings related to it

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,10 @@ import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:noteif/helper/colors.dart';
 import 'package:noteif/helper/utils.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'theme/themeModeChanger.dart';
+import 'package:provider/provider.dart';
+
+import 'helper/colors.dart';
 
 void main() {
   runApp(MyApp());
@@ -15,21 +19,42 @@ void main() {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      localizationsDelegates: [
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-        GlobalCupertinoLocalizations.delegate,
-      ],
-      supportedLocales: [
-        Locale("fa", "IR"),
-      ],
-      theme: ThemeData(
-          fontFamily: 'IRANSansMobile', primaryColor: AppColors.bondiBlue),
-      locale: Locale("fa", "IR"),
-//      navigatorObservers: <NavigatorObserver>[observer],
-      home: HomePage(),
+    return ChangeNotifierProvider<ThemeModeChanger>(
+          create: (_) => ThemeModeChanger(ThemeMode.system),
+          child: MaterialAppWithThemeMode(),
     );
+  }
+}
+
+class MaterialAppWithThemeMode extends StatelessWidget {
+
+  @override
+  Widget build(BuildContext context) {
+    final themeMode = Provider.of<ThemeModeChanger>(context);
+
+    return MaterialApp(
+        localizationsDelegates: [
+    GlobalMaterialLocalizations.delegate,
+    GlobalWidgetsLocalizations.delegate,
+    GlobalCupertinoLocalizations.delegate,
+        ],
+        supportedLocales: [
+    Locale("fa", "IR"),
+        ],
+        theme: ThemeData(
+      fontFamily: 'IRANSansMobile', 
+      primaryColor: AppColors.bondiBlue,
+      scaffoldBackgroundColor: AppColors.whiteSmoke
+      ),
+        darkTheme: ThemeData(
+          fontFamily: 'IRANSansMobile',
+          brightness: Brightness.dark
+        ),
+        themeMode: themeMode.getThemeMode(),
+        locale: Locale("fa", "IR"),
+//      navigatorObservers: <NavigatorObserver>[observer],
+        home: HomePage(),
+      );
   }
 }
 
@@ -94,20 +119,26 @@ class _HomePageState extends State<HomePage> {
 
   @override
   Widget build(BuildContext context) {
+
+    ThemeModeChanger _themeModeChanger = Provider.of<ThemeModeChanger>(context);
+
     final noteTextBox = Container(
-      decoration: BoxDecoration(
-          gradient: LinearGradient(
-        begin: Alignment.topCenter,
-        end: Alignment.bottomCenter,
-        colors: [AppColors.veryLightGray, AppColors.whiteSmoke],
-      )),
+      decoration: Theme.of(context).brightness == Brightness.light
+        ? BoxDecoration(
+          gradient:  LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [AppColors.veryLightGray, AppColors.whiteSmoke],
+          )
+      )
+      : BoxDecoration(color: Colors.grey[850])
+      ,
       width: double.infinity,
       padding: const EdgeInsets.all(20.0),
       child: Text(
         'Noteif',
         style: TextStyle(
           fontFamily: 'Chewy',
-          color: Colors.black,
           fontSize: 30.0,
         ),
         textAlign: TextAlign.center,
@@ -171,8 +202,27 @@ class _HomePageState extends State<HomePage> {
       child: Center(child: materialButton('ثبت یادداشت', setNote)),
     );
 
+
+    final themeModeSetting = Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        IconButton(
+          icon: Icon(Icons.brightness_auto),
+          onPressed: () => _themeModeChanger.setThemeMode(ThemeMode.system),
+        ),
+        IconButton(
+          icon: Icon(Icons.wb_sunny),
+          onPressed: () => _themeModeChanger.setThemeMode(ThemeMode.light),
+        ),
+        IconButton(
+          icon: Icon(Icons.brightness_2),
+          onPressed: () => _themeModeChanger.setThemeMode(ThemeMode.dark),
+        ),
+
+      ],
+    );
+
     return Scaffold(
-      backgroundColor: AppColors.whiteSmoke,
 //      appBar: emptyAppbar(),
       body: SafeArea(
         child: Container(
@@ -186,6 +236,7 @@ class _HomePageState extends State<HomePage> {
                 noteTextField,
                 saveNoteButton,
                 showNotificationWidgets,
+                themeModeSetting,
               ],
             ),
           ),

--- a/lib/theme/themeModeChanger.dart
+++ b/lib/theme/themeModeChanger.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class ThemeModeChanger with ChangeNotifier{
+  
+  ThemeMode _themeMode;
+
+  ThemeModeChanger(this._themeMode);
+
+  getThemeMode() => _themeMode;
+  setThemeMode(ThemeMode themeMode){
+    _themeMode = themeMode;
+
+    notifyListeners();
+      
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -154,6 +154,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.8"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   path:
     dependency: transitive
     description:
@@ -182,6 +189,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.5+1"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3
+  provider:
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Fixes #15 
- Create a new class named ```MaterialAppWithThemeMode``` in case of using ```provider``` package.
- Add two mode for dark-theme:
    - using system setting
    - choose manually for the desired theme

